### PR TITLE
Add ESM entrypoint for better three-shaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+# built files
+index.js
+
 # Dependency directories
 node_modules/

--- a/index.mjs
+++ b/index.mjs
@@ -11,7 +11,7 @@ const ENTITIES = {
 
 const ENT_REGEX = new RegExp(Object.keys(ENTITIES).join('|'), 'g')
 
-function join (array, separator) {
+export function join (array, separator) {
   if (separator === undefined || separator === null) {
     separator = ','
   }
@@ -21,7 +21,7 @@ function join (array, separator) {
   return new HtmlSafeString(['', ...Array(array.length - 1).fill(separator), ''], array)
 }
 
-function safe (value) {
+export function safe (value) {
   return new HtmlSafeString([String(value)], [])
 }
 
@@ -53,10 +53,6 @@ class HtmlSafeString {
   }
 }
 
-function escapeHtml (parts, ...subs) {
+export default function escapeHtml (parts, ...subs) {
   return new HtmlSafeString(parts, subs)
 }
-
-Object.assign(escapeHtml, { safe, join })
-
-module.exports = escapeHtml

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,18 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
+      "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
+      "dev": true
+    },
     "acorn": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
@@ -1463,6 +1475,25 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.26.0.tgz",
+      "integrity": "sha512-5HljNYn9icFvXX+Oe97qY5TWvnWhKqgGT0HGeWWqFPx7w7+Anzg7dfHMtUif7YYy6QxAgynDSwK6uxbgcrVUxw==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "dev": true
+        }
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "index.mjs",
   "scripts": {
     "test": "standard && node test",
-    "prepublish": "rollup index.mjs --file index.js --format cjs --exports named --footer 'module.exports = Object.assign(exports.default, exports);'"
+    "prepublish": "rollup index.mjs --file index.js --format cjs --exports named --no-esModule --footer 'module.exports = Object.assign(exports.default, exports);'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "1.1.2",
   "description": "Tag literal strings with this function to html escape interpolated values",
   "main": "index.js",
+  "module": "index.mjs",
   "scripts": {
-    "test": "standard && node test"
+    "test": "standard && node test",
+    "prepublish": "rollup index.mjs --file index.js --format cjs --exports named"
   },
   "repository": {
     "type": "git",
@@ -18,6 +20,7 @@
   ],
   "files": [
     "index.js",
+    "index.mjs",
     "index.d.ts"
   ],
   "author": "Jan Potoms",
@@ -27,6 +30,7 @@
   },
   "homepage": "https://github.com/janpot/escape-html-template-tag#readme",
   "devDependencies": {
+    "rollup": "1.26.0",
     "standard": "13.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "index.mjs",
   "scripts": {
     "test": "standard && node test",
-    "prepublish": "rollup index.mjs --file index.js --format cjs --exports named"
+    "prepublish": "rollup index.mjs --file index.js --format cjs --exports named --footer 'module.exports = Object.assign(exports.default, exports);'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Current approach breaks tree-shaking in module bundlers like Webpack. It's even not about the package itself but the user code. Ex. when you have setup like this:

```js
// A.js
import html from 'escape-html-template-tag';

export function foo() {
  return html``;
}

export const bar = 1;
```
```js
// B.js
import { bar } from './A';
```
where `B.js` is an app entrypoint, the `html` function suprisingly shows up in the final bundle. It's not supposed to be, as it's never used (only `bar` is imported, so the rest should be tree-shaked). ESM wersion works well, the library code is bundled only when actually used.