### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
   "main": "dist/index.js",
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index.modern.mjs"
+    "default": "./dist/index.modern.mjs",
+    "types": "./dist/index.d.ts"
   },
   "module": "dist/index.module.mjs",
   "unpkg": "dist/index.umd.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "tsc --noEmit --strict src/* && standard && node test/index.test.js",
-    "build": "rm -rf dist && microbundle --no-compress -f cjs,umd src/index.cjs.ts && microbundle --no-compress -f es,modern src/index.ts && mv dist/index.modern.js dist/index.modern.mjs && mv dist/index.modern.js.map dist/index.modern.mjs.map",
-    "prepare": "npm run build"
+    "prepublish": "rm -rf dist && microbundle --no-compress -f cjs,umd src/index.cjs.ts && microbundle --no-compress -f es,modern src/index.ts && mv dist/index.modern.js dist/index.modern.mjs && mv dist/index.modern.js.map dist/index.modern.mjs.map"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "tsc --noEmit --strict src/* && standard && node test/index.test.js",
-    "prepublish": "rm -rf dist && microbundle --no-compress -f cjs,umd src/index.cjs.ts && microbundle --no-compress -f es,modern src/index.ts && mv dist/index.modern.js dist/index.modern.mjs && mv dist/index.modern.js.map dist/index.modern.mjs.map"
+    "build": "rm -rf dist && microbundle --no-compress -f cjs,umd src/index.cjs.ts && microbundle --no-compress -f es,modern src/index.ts && mv dist/index.modern.js dist/index.modern.mjs && mv dist/index.modern.js.map dist/index.modern.mjs.map",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add types field in `exports`

Solve error from TypeScript 5:

There are types at '/path/escape-html-template-tag/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'escape-html-template-tag' library may need to update its package.json or typings.ts(7016)