### PR TITLE
Fix custom functions example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ import html from 'escape-html-template-tag'
 
 const anchor = (text, href) => html`<a href="${href}">${text}</a>`
 
-const list = items => html`
+const list = (...items) => html`
   <ul>
     ${items.map(item => html`<li>${item}</li>`)}
   </ul>


### PR DESCRIPTION
- The items aren't passed as an array in the example so this wouldn't work. I think rest parameters are nicer here